### PR TITLE
Add testing workaround in Getting Started Guide

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -19,9 +19,16 @@ To create or revise a submission, you will first need to create a local copy of 
 
 # Testing your Submission Locally #
 
-Once you've made your changes to your local branch, you can open a terminal and run the command "python3 check_sites.py". 
-When this command has finished you will either see "success" meaning your submission passed all of the checks, or you will see a 
-list of failed checks. 
+Once you've made your changes to your local branch, you can open a terminal and run the command `python3 check_sites.py`. 
+Currently, this will produce a number of check failures due to older submissions in the set failing recent changes to checks. If no members of your set
+are mentioned in the list of failed checks, then your submission should be fine. If you would like a cleaner way of looking for problems in your set,
+follow these steps: 
+<ol>
+ <li>Run `cp related_website_sets.JSON my_rws.JSON` in your shell</li>
+<li>Make your changes to `my_rws.JSON` and make sure `related_website_sets.JSON` is identical to the version in main.</li>
+<li>To test your local changes, run `python3 check_sites.py -i my_rws.JSON --with_diff`</li>
+<li>When you are ready to submit, copy your changes from `my_rws.JSON` into `related_website_sets.JSON` and delete `my_rws.JSON`</li>
+</ol>
 
 
 # Creating your Pull Request #


### PR DESCRIPTION
Because of changes to the Submission Checks, running `check_sites.py` locally will cause a number of failures to appear related to older submissions that are not compliant with the changes. In order to make the testing process smoother for prospective submitters, this PR adds an explanation of a workaround that can be used to run the checks locally without having to see failures caused by older submissions. 