### PR TITLE
Add unchecked fields to associated .well-known test

### DIFF
--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -967,7 +967,8 @@ def mock_open_and_load_json(*args, **kwargs):
         }
     elif args[0] == 'https://associated3.com' + WELL_KNOWN:
         return {
-            "primary": "https://primary4.com"
+            "primary": "https://primary4.com",
+            "unchecked": "some unchecked field"
         }
     elif args[0] == 'https://primary5.com' + WELL_KNOWN:
         return {

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -968,6 +968,7 @@ def mock_open_and_load_json(*args, **kwargs):
     elif args[0] == 'https://associated3.com' + WELL_KNOWN:
         return {
             "primary": "https://primary4.com",
+            "associatedSites": ["https://associated3.com"],
             "unchecked": "some unchecked field"
         }
     elif args[0] == 'https://primary5.com' + WELL_KNOWN:


### PR DESCRIPTION
This adds a unit test proof that it's fine to include non-`"primary"` fields in the .well-known files for non-primary sites, and even include unsupported fields, without causing a validation error.