### PR TITLE
Add scheme requirement

### DIFF
--- a/Well-Known-Specification.md
+++ b/Well-Known-Specification.md
@@ -6,7 +6,9 @@ This page describes the use and content of URIs with the path
 
 A site may demonstrate intentional opt-in to participation in a Related Website
 Set (RWS) by hosting a specific JSON file at the URI with a path of
-`/.well-known/related-website-set.json`.
+`/.well-known/related-website-set.json`. Such sites must use the `https` scheme
+in order to participate in RWS and host this well-known file. 
+
 ## Content
 
 The `/.well-known/related-website-set.json` file for the set primary of an RWS


### PR DESCRIPTION
In order to progress with registering the RWS well-known URI, we should specify what URI scheme we require, [as was suggested on the issue we filed](https://github.com/protocol-registries/well-known-uris/issues/40#issuecomment-1835374194).  