### PR TITLE
Fix local testing workflow

### DIFF
--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -41,12 +41,20 @@ Step 4: Testing your RWS locally
 
 Once you've made your changes to your local branch, you can open a terminal and run the command 
 
-`python3 check_sites.py --testing_sets=<your primary site>`
+`python3 check_sites.py --primaries=<your primary site>`
 
-You will get the results of any failed tests in the terminal. Otherwise, you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. If you would like to test multiple Related Website Sets at once, you can run the command above with multiple primaries in a comma separated list, like so:
+You will get the results of any failed tests in the terminal. Otherwise, you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. If you would like to test multiple Related Website Sets at once, you can run the command above with multiple primaries in a comma separated list. 
+
+For example:
+
+`python3 check_sites.py --primaries=https://foo.example`
+
+This would give the results of the checks for a set with `https://foo.example` as its primary.
 
 
-`python3 check_sites.py --testing_sets=<primary 1>,<primary 2>,<etc.>`
+`python3 check_sites.py --primaries=https://foo.example,https://bar.example`
+
+This would give the results for both the set with `https://foo.example` as its primary, and for the set with `https://bar.example` as its primary. 
 
 Step 5: Submitting your RWS
 ---------------------------

--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -39,7 +39,14 @@ Step 3: Ensuring your RWS meets the technical requirements
 Step 4: Testing your RWS locally
 --------------------------------
 
-Once you've made your changes to your local branch, you can open a terminal and run the command `python3 check_sites.py --single_set=<your primary site>`. You will get the restults of any failed tests on the command line. otherwise you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. You can also run the command `python3 check_sites.py`, without the `single_set` argument if you would like, but this will run the checks on the entire document, meaning you may see some failures related to other sets from your own. 
+Once you've made your changes to your local branch, you can open a terminal and run the command 
+
+`python3 check_sites.py --testing_sets=<your primary site>`
+
+You will get the results of any failed tests in the terminal. Otherwise, you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. If you would like to test multiple Related Website Sets at once, you can run the command above with multiple primaries in a comma separated list, like so:
+
+
+`python3 check_sites.py --testing_sets=<primary 1>,<primary 2>,<etc.>`
 
 Step 5: Submitting your RWS
 ---------------------------

--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -39,15 +39,7 @@ Step 3: Ensuring your RWS meets the technical requirements
 Step 4: Testing your RWS locally
 --------------------------------
 
-Once you've made your changes to your local branch, you can open a terminal and run the command `python3 check_sites.py`. Currently, this will produce a number of check failures due to older submissions in the set failing recent changes to checks. If no members of your set are mentioned in the list of failed checks, then your submission should be fine. If you would like a cleaner way of looking for problems in your set, follow these steps:
-
-1.  Run `cp related_website_sets.JSON my_rws.JSON` in your shell
-
-2.  Make your changes to `my_rws.JSON` and make sure `related_website_sets.JSON` is identical to the version in main.
-
-3.  To test your local changes, run `python3 check_sites.py -i my_rws.JSON --with_diff`. When this command finishes running, you will either see "success" (meaning your submission passed all of the checks) or you will see a list of failed checks.
-
-4.  When you are ready to submit, copy your changes from `my_rws.JSON` into `related_website_sets.JSON` and delete `my_rws.JSON`
+Once you've made your changes to your local branch, you can open a terminal and run the command `python3 check_sites.py --single_set=<your primary site>`. You will get the restults of any failed tests on the command line. otherwise you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. You can also run the command `python3 check_sites.py`, without the `single_set` argument if you would like, but this will run the checks on the entire document, meaning you may see some failures related to other sets from your own. 
 
 Step 5: Submitting your RWS
 ---------------------------

--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -41,11 +41,11 @@ Step 4: Testing your RWS locally
 
 Once you've made your changes to your local branch, you can open a terminal and run the command 
 
-`python3 check_sites.py --primaries=<your primary site>`
+`python3 check_sites.py --primaries=https://yourprimary.example`
 
 or, equivalently, run
 
-`python3 check_sites.py -p <your primary site>`
+`python3 check_sites.py -p https://yourprimary.example`
 
 You will get the results of any failed tests in the terminal. Otherwise, you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. If you would like to test multiple Related Website Sets at once, you can run the command above with multiple primaries in a comma separated list. 
 

--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -43,18 +43,28 @@ Once you've made your changes to your local branch, you can open a terminal and 
 
 `python3 check_sites.py --primaries=<your primary site>`
 
+or, equivalently, run
+
+`python3 check_sites.py -p <your primary site>`
+
 You will get the results of any failed tests in the terminal. Otherwise, you will see "success" if your changes are passing all of the checks. Make sure that the text of the primary site you're passing into the command line is identical to the primary site you have listed in the related_website_sets.JSON file, or the tests will fail. If you would like to test multiple Related Website Sets at once, you can run the command above with multiple primaries in a comma separated list. 
 
-For example:
+For example, to get the results of the checks for a set with `https://foo.example` as its primary, you would run
 
 `python3 check_sites.py --primaries=https://foo.example`
 
-This would give the results of the checks for a set with `https://foo.example` as its primary.
+or equivalently
 
+`python3 check_sites.py -p https://foo.example`
+
+
+To get the results for both the set with `https://foo.example` as its primary, and for the set with `https://bar.example` as its primary, you would run
 
 `python3 check_sites.py --primaries=https://foo.example,https://bar.example`
 
-This would give the results for both the set with `https://foo.example` as its primary, and for the set with `https://bar.example` as its primary. 
+or
+
+`python3 check_sites.py -p https://foo.example -p https://bar.example`
 
 Step 5: Submitting your RWS
 ---------------------------

--- a/check_sites.py
+++ b/check_sites.py
@@ -47,11 +47,11 @@ def find_diff_sets(old_sets, new_sets):
 def main():
     args = sys.argv[1:]
     input_file = 'related_website_sets.JSON'
-    testing_sets = []
+    cli_primaries = []
     input_prefix = ''
     with_diff = False
-    opts, _ = getopt.getopt(args, "i:", ["data_directory=", "with_diff", 
-                                         "testing_sets="])
+    opts, _ = getopt.getopt(args, "i:p:", ["data_directory=", "with_diff", 
+                                         "primaries="])
     for opt, arg in opts:
         if opt == '-i':
             input_file = arg
@@ -59,8 +59,8 @@ def main():
             input_prefix = arg
         if opt == '--with_diff':
             with_diff = True
-        if opt == '--testing_sets':
-            testing_sets = arg.split(',')
+        if opt == '--primaries' or opt == '-p':
+            cli_primaries.extend(arg.split(','))
 
     # Open and load the json of the new list
     with open(input_file) as f:
@@ -117,15 +117,12 @@ def main():
         check_sets, subtracted_sets = find_diff_sets(old_checker.load_sets(), rws_checker.load_sets())
     else:
         check_sets = rws_checker.load_sets()
-        if testing_sets:
-            temp_sets = {}
-            for testing_set in testing_sets:
-                if testing_set not in check_sets:
-                    error_texts.append("There was an error loading the set:\n" + testing_set +
-                        " could not be found in related_website_sets.JSON")
-                else:
-                    temp_sets.update({testing_set: check_sets[testing_set]})
-            check_sets = temp_sets
+        if cli_primaries:
+            absent_primaries = [p for p in cli_primaries if p not in check_sets]
+            for p in absent_primaries:
+                error_texts.append("There was an error loading the set:\n" + 
+                    p + " could not be found in related_website_sets.JSON")  
+            check_sets = {p: check_sets[p] for p in cli_primaries if p not in absent_primaries}
 
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)

--- a/check_sites.py
+++ b/check_sites.py
@@ -47,9 +47,11 @@ def find_diff_sets(old_sets, new_sets):
 def main():
     args = sys.argv[1:]
     input_file = 'related_website_sets.JSON'
+    single_set = ''
     input_prefix = ''
     with_diff = False
-    opts, _ = getopt.getopt(args, "i:", ["data_directory=", "with_diff"])
+    opts, _ = getopt.getopt(args, "i:", ["data_directory=", "with_diff", 
+                                         "single_set="])
     for opt, arg in opts:
         if opt == '-i':
             input_file = arg
@@ -57,6 +59,8 @@ def main():
             input_prefix = arg
         if opt == '--with_diff':
             with_diff = True
+        if opt == '--single_set':
+            single_set = arg
 
     # Open and load the json of the new list
     with open(input_file) as f:
@@ -111,10 +115,14 @@ def main():
                 return
         old_checker = RwsCheck(old_sites, etlds, icanns)
         check_sets, subtracted_sets = find_diff_sets(old_checker.load_sets(), rws_checker.load_sets())
-        # TODO: add variable and check for subtracted_sets in case of user 
-        # removing old set from the list
     else:
         check_sets = rws_checker.load_sets()
+        if single_set:
+            if single_set not in check_sets:
+                print("There was an error loading the set:\n" + single_set +
+                      " could not be found in related_website_sets.JSON")
+                return
+            check_sets = {single_set: check_sets[single_set]}
 
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)

--- a/check_sites.py
+++ b/check_sites.py
@@ -47,11 +47,11 @@ def find_diff_sets(old_sets, new_sets):
 def main():
     args = sys.argv[1:]
     input_file = 'related_website_sets.JSON'
-    single_set = ''
+    testing_sets = []
     input_prefix = ''
     with_diff = False
     opts, _ = getopt.getopt(args, "i:", ["data_directory=", "with_diff", 
-                                         "single_set="])
+                                         "testing_sets="])
     for opt, arg in opts:
         if opt == '-i':
             input_file = arg
@@ -59,8 +59,8 @@ def main():
             input_prefix = arg
         if opt == '--with_diff':
             with_diff = True
-        if opt == '--single_set':
-            single_set = arg
+        if opt == '--testing_sets':
+            testing_sets = arg.split(',')
 
     # Open and load the json of the new list
     with open(input_file) as f:
@@ -117,12 +117,15 @@ def main():
         check_sets, subtracted_sets = find_diff_sets(old_checker.load_sets(), rws_checker.load_sets())
     else:
         check_sets = rws_checker.load_sets()
-        if single_set:
-            if single_set not in check_sets:
-                print("There was an error loading the set:\n" + single_set +
-                      " could not be found in related_website_sets.JSON")
-                return
-            check_sets = {single_set: check_sets[single_set]}
+        if testing_sets:
+            temp_sets = {}
+            for testing_set in testing_sets:
+                if testing_set not in check_sets:
+                    error_texts.append("There was an error loading the set:\n" + testing_set +
+                        " could not be found in related_website_sets.JSON")
+                else:
+                    temp_sets.update({testing_set: check_sets[testing_set]})
+            check_sets = temp_sets
 
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)

--- a/check_sites.py
+++ b/check_sites.py
@@ -121,8 +121,8 @@ def main():
             absent_primaries = [p for p in cli_primaries if p not in check_sets]
             for p in absent_primaries:
                 error_texts.append("There was an error loading the set:\n" + 
-                    p + " could not be found in related_website_sets.JSON")  
-            check_sets = {p: check_sets[p] for p in cli_primaries if p not in absent_primaries}
+                    "could not find set with primary site " + p)  
+            check_sets = {p: check_sets[p] for p in cli_primaries if p in check_sets}
 
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)

--- a/check_sites.py
+++ b/check_sites.py
@@ -121,7 +121,7 @@ def main():
             absent_primaries = [p for p in cli_primaries if p not in check_sets]
             for p in absent_primaries:
                 error_texts.append("There was an error loading the set:\n" + 
-                    "could not find set with primary site " + p)  
+                    f"could not find set with primary site \"{p}\"")  
             check_sets = {p: check_sets[p] for p in cli_primaries if p in check_sets}
 
     # Run check on subtracted sets


### PR DESCRIPTION
Currently, if users would like to locally test their changes to related_website_sets.JSON, they have to use [an awkward workaround](https://github.com/GoogleChrome/related-website-sets/blob/main/Getting-Started.md#step-4-testing-your-rws-locally). This change makes the workflow much simpler for users by adding an optional command line argument they can pass to check_sites.py when running it locally. 