### PR TITLE
Update Related Website Set for Skyhigh Security/Trellix

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -453,6 +453,25 @@
              "https://elpais.uy"
           ]
        }
+    },
+    {
+      "contact": "sritejakumar.samudrala@skyhighsecurity.com",
+      "primary": "https://trellix.com",
+      "associatedSites": [
+        "https://myshn.net",
+        "https://skyhigh.cloud",
+        "https://shn.io"
+      ],
+      "rationaleBySite": {
+        "https://myshn.net": "Domain for Skyhigh Security Product",
+        "https://skyhigh.cloud": "Domain for Skyhigh Security Web Product",
+        "https://shn.io": "Domain for testing fabrics"
+      },
+      "ccTLDs": {
+        "https://myshn.net": [
+          "https://myshn.eu"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This change will hold the domains of Trellix and Skyhigh Products