### PR TITLE
Add Related Website Set for stripe.com

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -453,6 +453,17 @@
              "https://elpais.uy"
           ]
        }
-    }
+    },
+    {
+      "contact": "admin@stripe.com",
+      "primary": "https://stripe.com",
+      "serviceSites": [
+          "https://stripecdn.com",
+          "https://stripe.network"
+      ],
+      "rationaleBySite": {
+          "https://stripecdn.com": "Serves static assets accelerating page loads and sandboxes select Javascript",
+          "https://stripe.network": "Receives telemetry preventing fraud across Stripe services"
+      }
   ]
 }

--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -465,5 +465,6 @@
           "https://stripecdn.com": "Serves static assets accelerating page loads and sandboxes select Javascript",
           "https://stripe.network": "Receives telemetry preventing fraud across Stripe services"
       }
+    }
   ]
 }


### PR DESCRIPTION
* Adds Related Website Set for stripe.com
* Well-known entries are in place for
  * https://stripe.com/.well-known/related-website-set.json (primary)
  * https://stripecdn.com/.well-known/related-website-set.json (service)
  * https://stripe.network/.well-known/related-website-set.json (service)
* Root of both service domains redirect to primary home page
