### PR TITLE
Prevents redirects in the find_robots_txt check

### DIFF
--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -482,7 +482,7 @@ class RwsCheck:
         for curr_set in check_sets.values():
             for service_site in curr_set.service_sites:
                 try:
-                    r_service = requests.get(service_site, timeout=10)
+                    r_service = requests.get(service_site, timeout=10, allow_redirects=False)
                     if 'X-Robots-Tag' not in r_service.headers:
                         self.error_list.append(f"The service site {service_site} does not have an X-Robots-Tag in its "
                          + "header")

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -1003,6 +1003,7 @@ class MockTestsClass(unittest.TestCase):
         self.assertEqual(rws_check.error_list, ["The service site " +
         "https://service1.com " +
         "does not have an X-Robots-Tag in its header"])
+        mock_get.assert_called_once_with('https://service1.com', timeout=10, allow_redirects=False)
         
     @mock.patch('requests.get', side_effect=mock_get)
     def test_robots_wrong_tag(self, mock_get):
@@ -1024,6 +1025,7 @@ class MockTestsClass(unittest.TestCase):
         self.assertEqual(rws_check.error_list, ["The service site " +
         "https://service2.com " +
         "does not have a 'noindex' or 'none' tag in its header"])
+        mock_get.assert_called_once_with('https://service2.com', timeout=10, allow_redirects=False)
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_robots_expected_tag(self, mock_get):
@@ -1043,6 +1045,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = rws_check.load_sets()
         rws_check.find_robots_txt(loaded_sets)
         self.assertEqual(rws_check.error_list, [])
+        mock_get.assert_called_once_with('https://service3.com', timeout=10, allow_redirects=False)
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_robots_none_tag(self, mock_get):
@@ -1062,6 +1065,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = rws_check.load_sets()
         rws_check.find_robots_txt(loaded_sets)
         self.assertEqual(rws_check.error_list, [])
+        mock_get.assert_called_once_with('https://service4.com', timeout=10, allow_redirects=False)
 
     # We run a similar set of mock tests for ads.txt
     @mock.patch('requests.get', side_effect=mock_get)


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/related-website-sets/issues/246 by explicitly disabling redirects on the `find_robots_txt` check. Adds asserts that this is the case in the tests.

This allows for the case where a service domain redirects to another domain that does not have the `X-Robots-Tag`.

This shouldn't change the behavior of non-redirecting which must either 4xx or 5xx when the home page is hit.

> Must have a homepage that redirects to a different domain or results in 4xx (client error) or 5xx (server error).