### PR TITLE
Fix bug with concatenating JSONDecodeError

### DIFF
--- a/check_sites.py
+++ b/check_sites.py
@@ -68,8 +68,8 @@ def main():
             rws_sites = json.load(f)
         except Exception as inst:
         # If the file cannot be loaded, we will not run any other checks
-            print("There was an error when loading "+ input_file + 
-                  "\nerror was: " + inst)
+            print(f"There was an error when loading {input_file};" 
+                  f"\nerror was:  {inst}")
             return  
      
 


### PR DESCRIPTION
JSONDecodeErrors were not properly handled in the `check_sites.py` script, meaning that the comment-bot wasn't surfacing the error to the submitters. This change fixes the formatting. 