### PR TITLE
Trigger "RWS submission checks" action daily at 9am EST

### DIFF
--- a/.github/workflows/rws-submissions-checks.yml
+++ b/.github/workflows/rws-submissions-checks.yml
@@ -14,7 +14,7 @@
 name: RWS submission checks
 on: 
   schedule:
-  - cron: '0 14 * * *' #triggers job at 9am EST each day
+  - cron: '0 14 * * 2' # 2pm UTC each Tuesday
   pull_request_target:
 jobs:
   PR-Actions:

--- a/.github/workflows/rws-submissions-checks.yml
+++ b/.github/workflows/rws-submissions-checks.yml
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: RWS submission checks
-on: pull_request_target
+on: 
+  schedule:
+  - cron: '0 14 * * *' #triggers job at 9am EST each day
+  pull_request_target:
 jobs:
   PR-Actions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 This commit will cause the "RWS submission checks" to run daily at 9am EST. It utilizes the "schedule" event trigger and cron as described in https://docsgithub.com/en/actions/using-workflows/events-that-trigger-workflows#schedule