### PR TITLE
Added related website set for sortd.mobi

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -537,6 +537,14 @@
         "https://ya.ru": ["https://ya.cc"],
         "https://yandex.ru": ["https://yandex.az", "https://yandex.by", "https://yandex.kz", "https://yandex.md", "https://yandex.tj", "https://yandex.tm", "https://yandex.uz", "https://yandex.st", "https://yandex.com", "https://yandex.com.am", "https://yandex.com.ru"]
       }
+    },
+    {
+      "primary":"https://super.sortd.mobi",
+      "contact": "sortd-team@readwhere.com",
+      "associatedSites": ["https://kyc.rwadx.com"],
+      "rationaleBySite": {
+          "https://kyc.mediology.mobi": "These websites are all used by the internal employees of Mediology Software."
+      }
     }
   ]
 }


### PR DESCRIPTION
Added related website sets entry :-1
primary: "https://super.sortd.mobi"
assocaited: ["https://kyc.rwadx.com"]

Both of these are domains are used by mediology software pvt ltd.