### PR TITLE
Remove robots references

### DIFF
--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -465,19 +465,15 @@ class RwsCheck:
         """Checks service sites to see if they have a robots.txt subdomain.
 
 
-        Iterates through all service_sites in each RwsSet provided, and makes
-        a get request to site/robots.txt for each. This request should return
-        an error 4xx, 5xx, or a timeout error. If it does not, and the page 
-        does exist, then it is expected that the site contains a X-Robots-Tag
-        in its header. If none of these conditions is met, an error is appended
-        to the error list.
+        Iterates through all service_sites in each RwsSet provided, and checks 
+        that the returned page contains an X-Robots-Tag in its header. If not, 
+        an error is appended to the error list.
 
         Args:
             check_sets: Dict[string, RwsSet]
         Returns:
             None
         """
-        exception_retries = "Max retries exceeded with url: /robots.txt"
         exception_timeout = "Read timed out. (read timeout=10)"
         for curr_set in check_sets.values():
             for service_site in curr_set.service_sites:
@@ -496,10 +492,9 @@ class RwsCheck:
                                         "'noindex' or 'none' tag in its header"
                                         )
                 except Exception as inst:
-                    if exception_retries not in str(inst):
-                        if exception_timeout not in str(inst):
-                            self.error_list.append(
-                                f"Unexpected error for service site: {service_site}; Received error: {inst}")
+                    if exception_timeout not in str(inst):
+                        self.error_list.append(
+                            f"Unexpected error for service site: {service_site}; Received error: {inst}")
 
     def find_ads_txt(self, check_sets):
         """Checks to see if service sites have an ads.txt subdomain. 

--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -474,7 +474,6 @@ class RwsCheck:
         Returns:
             None
         """
-        exception_timeout = "Read timed out. (read timeout=10)"
         for curr_set in check_sets.values():
             for service_site in curr_set.service_sites:
                 try:
@@ -492,7 +491,6 @@ class RwsCheck:
                                         "'noindex' or 'none' tag in its header"
                                         )
                 except Exception as inst:
-                    if exception_timeout not in str(inst):
                         self.error_list.append(
                             f"Unexpected error for service site: {service_site}; Received error: {inst}")
 

--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -461,7 +461,7 @@ class RwsCheck:
                         self.error_list.append(
                             f"The provided country code: {tld}, in: {site} is not a ICANN registered country code")
 
-    def find_robots_txt(self, check_sets):
+    def find_robots_tag(self, check_sets):
         """Checks service sites to see if they have a robots.txt subdomain.
 
 

--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -491,8 +491,8 @@ class RwsCheck:
                                         "'noindex' or 'none' tag in its header"
                                         )
                 except Exception as inst:
-                        self.error_list.append(
-                            f"Unexpected error for service site: {service_site}; Received error: {inst}")
+                    self.error_list.append(
+                        f"Unexpected error for service site: {service_site}; Received error: {inst}")
 
     def find_ads_txt(self, check_sets):
         """Checks to see if service sites have an ads.txt subdomain. 

--- a/check_sites.py
+++ b/check_sites.py
@@ -134,7 +134,7 @@ def main():
         rws_checker.find_invalid_eTLD_Plus1,
         rws_checker.find_invalid_well_known, 
         rws_checker.find_invalid_alias_eSLDs, 
-        rws_checker.find_robots_txt, 
+        rws_checker.find_robots_tag, 
         rws_checker.find_ads_txt, 
         rws_checker.check_for_service_redirect
         ]

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -1004,7 +1004,7 @@ class MockTestsClass(unittest.TestCase):
                      etlds=None,
                      icanns=set())
         loaded_sets = rws_check.load_sets()
-        rws_check.find_robots_txt(loaded_sets)
+        rws_check.find_robots_tag(loaded_sets)
         self.assertEqual(rws_check.error_list, ["The service site " +
         "https://service1.com " +
         "does not have an X-Robots-Tag in its header"])
@@ -1025,7 +1025,7 @@ class MockTestsClass(unittest.TestCase):
                      etlds=None,
                      icanns=set())
         loaded_sets = rws_check.load_sets()
-        rws_check.find_robots_txt(loaded_sets)
+        rws_check.find_robots_tag(loaded_sets)
         self.assertEqual(rws_check.error_list, ["The service site " +
         "https://service2.com " +
         "does not have a 'noindex' or 'none' tag in its header"])
@@ -1046,7 +1046,7 @@ class MockTestsClass(unittest.TestCase):
                      etlds=None,
                      icanns=set())
         loaded_sets = rws_check.load_sets()
-        rws_check.find_robots_txt(loaded_sets)
+        rws_check.find_robots_tag(loaded_sets)
         self.assertEqual(rws_check.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1065,7 +1065,7 @@ class MockTestsClass(unittest.TestCase):
                      etlds=None,
                      icanns=set())
         loaded_sets = rws_check.load_sets()
-        rws_check.find_robots_txt(loaded_sets)
+        rws_check.find_robots_tag(loaded_sets)
         self.assertEqual(rws_check.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1083,7 +1083,7 @@ class MockTestsClass(unittest.TestCase):
                      etlds=None,
                      icanns=set())
         loaded_sets = rws_check.load_sets()
-        rws_check.find_robots_txt(loaded_sets)
+        rws_check.find_robots_tag(loaded_sets)
         self.assertEqual(rws_check.error_list, [])
 
     # We run a similar set of mock tests for ads.txt


### PR DESCRIPTION
While the robots check was modified in PR #28, that change did not properly modify the description of the function, and it left some extraneous bits of code. This Pr fixes resolves those issues. 