### PR TITLE
add cleartripcorp data in  related_website_sets

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -640,6 +640,10 @@
         "https://etfacademy.it": "An Italian language education site about ETFs. The iShares by BlackRock branding is clearly visible on the site.",
         "https://ishares.com": "iShares is BlackRock's ETF brand. The branding is clearly visible on the site." 
     }
+  },
+  {
+    "contact": "kanishk.gupta@cleartrip.com",
+    "primary": "https://ctdrive.cleartripcorp.com"
   }
   ]
 }

--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -643,7 +643,8 @@
   },
   {
     "contact": "kanishk.gupta@cleartrip.com",
-    "primary": "https://ctdrive.cleartripcorp.com"
+    "primary": "https://ctdrive.cleartripcorp.com",
+    "rationaleBySite": {}
   }
   ]
 }


### PR DESCRIPTION
We open google docs link in iframe in https://ctdrive.cleartripcorp.com/ adding this domain to related website sets