### PR TITLE
Update related_website_sets.JSON

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1,6 +1,16 @@
 {
   "sets": [
     {
+      "contact": "oterrell28@gmail.com",
+      "primary": "https://sackrace.ai",
+      "serviceSites": [
+        "https://socket-to-me.vip"
+      ],
+      "rationaleBySite": {
+        "https://socket-to-me.vip": "A headless server to augment application that has a primary serverless architecture."
+      }
+    },
+    {
       "contact": "il.mrbit@gmail.com",
       "primary": "https://poalim.xyz",
       "associatedSites": [


### PR DESCRIPTION
Encrypted JWT tokens are used in the primary serverless architecture for authenticated sessions. I need this value present in requests to my custom server as well for security reasons. This server is needed for server-based use cases that are inaccessible otherwise. This cookie is one of the good guys.