### PR TITLE
Fix check for primaries in subsets

### DIFF
--- a/RwsCheck.py
+++ b/RwsCheck.py
@@ -143,7 +143,7 @@ class RwsCheck:
                     "This primary is already registered in another related website"
                     + f" set: {primary}")
             else:
-                site_list.update(primary)
+                site_list.add(primary)
             # Check the associated sites
             associated_overlap = set(rws.associated_sites) & site_list
             if associated_overlap:

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -330,6 +330,35 @@ class TestCheckExclusivity(unittest.TestCase):
         self.assertEqual(rws_check.error_list, 
          ["This primary is already registered in another"
                         + " related website set: https://primary2.com"])
+        
+    def test_primary_overlap(self):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://primary.com",
+                    "associatedSites": ["https://associated1.com"],
+                    "serviceSites": ["https://primary.com"],
+                    "rationaleBySite": {}
+                },
+                {
+                    "primary": "https://primary2.com",
+                    "associatedSites": ["https://primary.com"],
+                    "serviceSites": ["https://service2.com"],
+                    "rationaleBySite": {}
+                }
+            ]
+        }
+        rws_check = RwsCheck(rws_sites=json_dict,
+                      etlds=None,
+                       icanns=set())
+        loaded_sets = rws_check.load_sets()
+        rws_check.check_exclusivity(loaded_sets)
+        self.assertEqual(rws_check.error_list, 
+         ["These service sites are already registered in another"
+                        + " related website set: {'https://primary.com'}",
+          "These associated sites are already registered in another" 
+                        + " related website set: {'https://primary.com'}"])
                 
     def test_expected_case(self):
         json_dict = {


### PR DESCRIPTION
There is currently a bug in how primaries are checked for as members of sets, causing the exclusivity check to improperly pass submissions that violate our guidelines. This PR fixes the exclusivity check, and adds additional testing to verify it. 