### PR TITLE
Update related_website_sets.JSON

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -772,6 +772,24 @@
     "rationaleBySite": {
       "https://tolteck.app": "Tolteck application"
     }
+  },
+  {
+      "contact": "datateam@centralmediacsoport.hu",
+      "primary": "https://p24.hu",
+      "associatedSites": [
+          "https://24.hu",
+          "https://startlap.hu",
+          "https://nlc.hu",
+          "https://hazipatika.com",
+          "https://nosalty.hu"
+      ],
+      "rationaleBySite": {
+          "https://24.hu": "Hungarian news portal",
+          "https://startlap.hu": "Hungarian news aggregator site and link collection",
+          "https://nlc.hu": "Hungarian women's online magazine",
+          "https://hazipatika.com": "Hungarian health portal",
+          "https://nosalty.hu": "Hungarian recipe portal"
+      }
   }
   ]
 }


### PR DESCRIPTION
Adds p24.hu and 24.hu, startlap.hu, nlc.hu, hazipatika.com, nosalty.hu as related sites