### PR TITLE
Alert in comment on system file changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ on:
   schedule:
   - cron: '0 14 * * 2' # 2pm UTC each Tuesday
 jobs:
-  build:
+  MAIN-Actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,15 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
         cache: 'pip'
         check-latest: true
     - name: Run Tests and Validate JSON
       run: |
-        git diff --name-only main > files.txt
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
         python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
@@ -35,11 +32,9 @@ jobs:
       uses: andstor/file-reader-action@v1
       with:
         path: "results.txt"
-    - name: Read the Files Changed
+    - name: Read the Changed Files
       id: read_files
-      uses: andstor/file-reader-action@v1
-      with:
-        path: "files.txt"
+      uses: tj-actions/changed-files@v45
     - name: Failure Comment
       if: steps.read_results.outputs.contents != 'success'
       run: |
@@ -49,7 +44,7 @@ jobs:
       if: steps.read_results.outputs.contents == 'success'
       run: echo "The RWS JSON was successfully validated!" > message.txt
     - name: System Comment
-      if: steps.read_files_modified.outputs.contents != 'related_website_sets.JSON'
+      if: steps.read_files.outputs.all_changed_and_modified_files_count != 'related_website_sets.JSON'
       run: echo "\n\n***THIS PR CONTAINS SYSTEM CHANGES***" >> message.txt
     - name: Write Comment
       uses: mshick/add-pr-comment@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Pull Request Validations
-on: pull_request
+on: pull_request_target
 jobs:
   PR-Actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-python@v5
       with:
         cache: 'pip'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,9 @@ jobs:
       run: echo "The RWS JSON was successfully validated!" > message.txt
     - name: System Comment
       if: steps.read_files.outputs.all_changed_and_modified_files_count != 'related_website_sets.JSON'
-      run: echo "\n\n***THIS PR CONTAINS SYSTEM CHANGES***" >> message.txt
+      run: |
+        echo "<br/>***THIS PR CONTAINS SYSTEM CHANGES***:<br/>" >> message.txt
+        echo "${{ steps.read_files.outputs.all_changed_and_modified_files_count }}" >> message.txt
     - name: Write Comment
       uses: mshick/add-pr-comment@v2
       with:   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,8 +46,9 @@ jobs:
     - name: System Comment
       if: steps.read_files.outputs.all_changed_and_modified_files != 'related_website_sets.JSON'
       run: |
-        echo "<br/>***THIS PR CONTAINS SYSTEM CHANGES***:" >> message.txt
+        echo "<br/>***THIS PR CONTAINS SYSTEM CHANGES:***" >> message.txt
         echo "${{ steps.read_files.outputs.all_changed_and_modified_files }}" >> message.txt
+        echo "***PLEASE REVIEW WITH CARE***" >> message.txt
     - name: Write Comment
       uses: mshick/add-pr-comment@v2
       with:   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,10 +44,10 @@ jobs:
       if: steps.read_results.outputs.contents == 'success'
       run: echo "The RWS JSON was successfully validated!" > message.txt
     - name: System Comment
-      if: steps.read_files.outputs.all_changed_and_modified_files_count != 'related_website_sets.JSON'
+      if: steps.read_files.outputs.all_changed_and_modified_files != 'related_website_sets.JSON'
       run: |
-        echo "<br/>***THIS PR CONTAINS SYSTEM CHANGES***:<br/>" >> message.txt
-        echo "${{ steps.read_files.outputs.all_changed_and_modified_files_count }}" >> message.txt
+        echo "<br/>***THIS PR CONTAINS SYSTEM CHANGES***:" >> message.txt
+        echo "${{ steps.read_files.outputs.all_changed_and_modified_files }}" >> message.txt
     - name: Write Comment
       uses: mshick/add-pr-comment@v2
       with:   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Pull Request Validations
-on: pull_request_target
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,14 +24,20 @@ jobs:
         check-latest: true
     - name: Run Tests and Validate JSON
       run: |
+        git diff --name-only origin/main > files.txt
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
         python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
-    - name: Read the result
+    - name: Read the Validation Results
       id: read_results
       uses: andstor/file-reader-action@v1
       with:
         path: "results.txt"
+    - name: Read the Files Changed
+      id: read_files
+      uses: andstor/file-reader-action@v1
+      with:
+        path: "files.txt"
     - name: Failure Comment
       if: steps.read_results.outputs.contents != 'success'
       run: |
@@ -40,6 +46,9 @@ jobs:
     - name: Success Comment
       if: steps.read_results.outputs.contents == 'success'
       run: echo "The RWS JSON was successfully validated!" > message.txt
+    - name: System Comment
+      if: steps.read_files_modified.outputs.contents != 'related_website_sets.JSON'
+      run: echo "\n\n***THIS PR CONTAINS SYSTEM CHANGES***" >> message.txt
     - name: Write Comment
       uses: mshick/add-pr-comment@v2
       with:   

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@
 name: Pull Request Validations
 on: pull_request
 jobs:
-  build:
+  PR-Actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
         check-latest: true
     - name: Run Tests and Validate JSON
       run: |
-        git diff --name-only origin/main > files.txt
+        git diff --name-only main > files.txt
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
         python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt


### PR DESCRIPTION
Let's update the GitHub comment with an alert if system files (non-RWS-JSON) changes are in the PR.

This also fixes an issue with the name of the PR build that prevents checks from looking as though they passed.

Here's an example of the comment:
![image](https://github.com/user-attachments/assets/be02e77f-e7e1-4bd0-a249-00f15996fff8)
