### PR TITLE
Fix checkout target

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
     - uses: actions/setup-python@v5
       with:
         cache: 'pip'


### PR DESCRIPTION
We want the action to initiate from the base commit on the main repo, but want to evaluate the code on the merge commit.