### PR TITLE
Use unified diff format when reporting formatting issues

### DIFF
--- a/check_sites.py
+++ b/check_sites.py
@@ -44,13 +44,13 @@ def parse_rws_json(rws_json_string, strict_formatting):
         # Add final newline by convention
         formatted_file = json.dumps(rws_sites, indent=2, ensure_ascii=False) + "\n"
         if rws_json_string != formatted_file:
-            diff = difflib.ndiff(
+            diff = difflib.unified_diff(
                 rws_json_string.splitlines(keepends=True),
                 formatted_file.splitlines(keepends=True),
+                fromfile="PR file",
+                tofile="expected",
             )
-            # Only show lines with differences
-            filtered_diff = (line for line in diff if len(line) > 0 and line[0] != " ")
-            joined_diff = "".join(filtered_diff)
+            joined_diff = "".join(diff)
             return (
                 None,
                 f"Formatting for JSON is incorrect;\nerror was:\n```diff\n{joined_diff}\n```",

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -57,7 +57,20 @@ class TestLoadFile(unittest.TestCase):
             parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', True),
             (
                 None,
-                'Formatting for JSON is incorrect;\nerror was:\n```diff\n-   "a": "foo", \n?              -\n+   "a": "foo",\n-     "b": "bar"\n? --\n+   "b": "bar"\n-   \n```',
+                """Formatting for JSON is incorrect;
+error was:
+```diff
+--- PR file
++++ expected
+@@ -1,5 +1,4 @@
+ {
+-  "a": "foo", 
+-    "b": "bar"
++  "a": "foo",
++  "b": "bar"
+ }
+-  
+```""",
             ),
         )
         self.assertEqual(
@@ -969,7 +982,6 @@ def mock_open_and_load_json(*args, **kwargs):
 
 
 class MockTestsClass(unittest.TestCase):
-
     # We patch requests.get with our mocked method. We'll pass
     # in the relevant urls, and get our responses for robots checks
     @mock.patch("requests.get", side_effect=mock_get)


### PR DESCRIPTION
I think this will give more context (like line numbers) when reporting formatting differences, that should make it easier to know where the problems are.