### PR TITLE
Split pull request jobs

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Main Branch Validations
+name: Code Validations
 on:
   pull_request:
     branches:
@@ -22,7 +22,7 @@ on:
   schedule:
   - cron: '0 14 * * 2' # 2pm UTC each Tuesday
 jobs:
-  MAIN-Actions:
+  Code-Actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -26,12 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Get the PR JSON
-      uses: actions/checkout@v4
-      with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
-        path: "pull-request"
-        sparse-checkout: "related_website_sets.JSON"
     - uses: actions/setup-python@v5
       with:
         check-latest: true

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Get the PR version of the files
+    - name: Get the PR JSON
       uses: actions/checkout@v4
       with:
         ref: "refs/pull/${{ github.event.number }}/merge"

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
-        python3 check_sites.py -i pull-request/related_website_sets.JSON --with_diff --strict_formatting > results.txt
+        python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
     - name: Read Results
       id: read_results
       uses: andstor/file-reader-action@v1

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Get the PR version of the files
+      uses: actions/checkout@v4
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
+        path: "pull-request"
+        sparse-checkout: "related_website_sets.JSON"
     - uses: actions/setup-python@v5
       with:
         check-latest: true
@@ -34,7 +40,7 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
-        python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
+        python3 check_sites.py -i pull-request/related_website_sets.JSON --with_diff --strict_formatting > results.txt
     - name: Read Results
       id: read_results
       uses: andstor/file-reader-action@v1

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: JSON Validations
-on: pull_request
+on: pull_request_target
 jobs:
   JSON-Actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Pull Request Validations
-on: pull_request
+on: pull_request_target
 jobs:
   PR-Actions:
     runs-on: ubuntu-latest
@@ -21,11 +21,10 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         check-latest: true
-    - uses: psf/black@stable
-    - name: Run Tests and Validate JSON
+    - name: Validate JSON
       run: |
         pip3 install -r requirements.txt
-        python3 tests/rws_tests.py
+        git checkout "refs/pull/${{ github.event.number }}/merge" -- related_website_sets.JSON
         python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
     - name: Read the Validation Results
       id: read_results

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: JSON Validations
-on: pull_request_target
+on: pull_request
 jobs:
   JSON-Actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Get the PR JSON
+      uses: actions/checkout@v4
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
+        path: "pull-request"
+        sparse-checkout: "related_website_sets.JSON"
     - uses: actions/setup-python@v5
       with:
         check-latest: true
@@ -25,7 +31,7 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         git checkout "refs/pull/${{ github.event.number }}/merge" -- related_website_sets.JSON
-        python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
+        python3 check_sites.py -i pull-request/related_website_sets.JSON --with_diff --strict_formatting > results.txt
     - name: Read the Validation Results
       id: read_results
       uses: andstor/file-reader-action@v1

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: Pull Request Validations
+name: JSON Validations
 on: pull_request_target
 jobs:
-  PR-Actions:
+  JSON-Actions:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Validate JSON
       run: |
         pip3 install -r requirements.txt
-        git checkout "refs/pull/${{ github.event.number }}/merge" -- related_website_sets.JSON
         python3 check_sites.py -i pull-request/related_website_sets.JSON --with_diff --strict_formatting > results.txt
     - name: Read the Validation Results
       id: read_results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@
 # limitations under the License.
 name: Main Branch Validations
 on:
+  pull_request:
+    branches:
+    - main
   push:
     branches:
     - main


### PR DESCRIPTION
We need two jobs:
1. a job that can only be triggered by a trusted source that runs new python code
2. a job that can be triggered by any fork, but just evaluates the new JSON and can make comments