### PR TITLE
Add JSON Actions Summary

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -58,6 +58,8 @@ jobs:
       with:   
         message-path: "message.txt" 
         refresh-message-position: true
+    - name: Write Summary
+      run: cat message.txt >> $GITHUB_STEP_SUMMARY
     - name: Record Failure
       if: steps.read_results.outputs.contents != 'success'
       uses: actions/github-script@v3


### PR DESCRIPTION
Let's use https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary too, then maybe we can remove the comment in the future.