### PR TITLE
Revert "gfk sensic domains "

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1004,16 +1004,6 @@
       "rationaleBySite": {
         "https://zoom.com": "marketing new homepages for SEO purposes"
       }
-    },
-    {
-      "contact": "dimitar.andonov@gfk.com",
-      "primary": "https://sensic.net",
-      "associatedSites": [
-        "https://sensics.org"
-      ],
-      "rationaleBySite": {
-        "https://sensics.org": "Domain for test purposes."
-      }
     }
   ]
 }


### PR DESCRIPTION
Reverts GoogleChrome/related-website-sets#710

Instead of merging test sets, users should be [using flags](https://developers.google.com/privacy-sandbox/blog/first-party-sets-testing-instructions#how_to_test_locally) for pure testing purposes. 

cc @dimitarandonov