### PR TITLE
Refactor code.yml Action

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -19,8 +19,6 @@ on:
   push:
     branches:
     - main
-  schedule:
-  - cron: '0 14 * * 2' # 2pm UTC each Tuesday
 permissions: {}
 jobs:
   Code-Actions:
@@ -31,18 +29,7 @@ jobs:
       with:
         check-latest: true
     - uses: psf/black@stable
-    - name: Run Tests and Validate JSON
+    - name: Run Tests
       run: |
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
-        python3 check_sites.py --strict_formatting > results.txt
-    - name: Read Results
-      id: read_results
-      uses: andstor/file-reader-action@v1
-      with:
-        path: "results.txt"
-    - name: Record Failure
-      if: steps.read_results.outputs.contents != 'success'
-      uses: actions/github-script@v3
-      with:
-        script: core.setFailed('This run has failed.')

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
-        python3 check_sites.py -i related_website_sets.JSON --with_diff --strict_formatting > results.txt
+        python3 check_sites.py --strict_formatting > results.txt
     - name: Read Results
       id: read_results
       uses: andstor/file-reader-action@v1

--- a/.github/workflows/json_main.yml
+++ b/.github/workflows/json_main.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/json_main.yml
+++ b/.github/workflows/json_main.yml
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: JSON Validations for Trunk
+on:
+  push:
+    branches:
+    - main
+  schedule:
+  - cron: '0 14 * * 2' # 2pm UTC each Tuesday
+permissions: {}
+jobs:
+  Code-Actions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        check-latest: true
+    - uses: psf/black@stable
+    - name: Run Tests and Validate JSON
+      run: |
+        pip3 install -r requirements.txt
+        python3 check_sites.py --strict_formatting > results.txt
+    - name: Read Results
+      id: read_results
+      uses: andstor/file-reader-action@v1
+      with:
+        path: "results.txt"
+    - name: Record Failure
+      if: steps.read_results.outputs.contents != 'success'
+      uses: actions/github-script@v3
+      with:
+        script: core.setFailed('This run has failed.')

--- a/.github/workflows/json_main.yml
+++ b/.github/workflows/json_main.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         check-latest: true
     - uses: psf/black@stable
-    - name: Run Tests and Validate JSON
+    - name: Validate JSON
       run: |
         pip3 install -r requirements.txt
         python3 check_sites.py --strict_formatting > results.txt

--- a/.github/workflows/json_pr.yml
+++ b/.github/workflows/json_pr.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: JSON Validations
+name: JSON Validations for PRs
 on: pull_request_target
 permissions:
   pull-requests: write

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -163,7 +163,7 @@ class TestValidateSchema(unittest.TestCase):
         rws_check = RwsCheck(rws_sites=json_dict, etlds=None, icanns=set(["ca"]))
         with self.assertRaisesRegex(
             ValidationError,
-            "Failed validating 'uniqueItems' in schema\['properies'\]\['sets'\]:",
+            "Failed validating 'uniqueItems' in schema\['properties'\]\['sets'\]:",
         ):
             rws_check.validate_schema("SCHEMA.json")
 

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -163,7 +163,7 @@ class TestValidateSchema(unittest.TestCase):
         rws_check = RwsCheck(rws_sites=json_dict, etlds=None, icanns=set(["ca"]))
         with self.assertRaisesRegex(
             ValidationError,
-            "Failed validating 'uniqueItems' in schema\['properties'\]\['sets'\]:",
+            "Failed validating 'uniqueItems' in schema\['properies'\]\['sets'\]:",
         ):
             rws_check.validate_schema("SCHEMA.json")
 


### PR DESCRIPTION
The prior code.yml action was validating no RWS sets and running tests, and it did this on PRs, main, and CRON.

We want to validate all sets on main/CRON but not block PRs.

code.yml now just runs tests on PRs and main.
json.yml was renamed json_pr.yml with no changes.
json_main.yml was added, and validates all RWS sets on main and CRON.