### PR TITLE
Allow other errors to be listed when there is a formatting error

### DIFF
--- a/check_sites.py
+++ b/check_sites.py
@@ -108,7 +108,7 @@ def main():
         (rws_sites, error) = parse_rws_json(rws_json_string, strict_formatting)
     except Exception as inst:
         # If the file cannot be loaded, we will not run any other checks
-        print (f"There was an error when parsing the JSON;\nerror was:  {inst}")
+        print(f"There was an error when parsing the JSON;\nerror was:  {inst}")
         return
     if error is not None:
         error_texts.append(error)

--- a/check_sites.py
+++ b/check_sites.py
@@ -72,6 +72,7 @@ def find_diff_sets(old_sets, new_sets):
     }
     return diff_sets, subtracted_sets
 
+
 def run_nonbreaking_checks(rws_checker, rws_json_string, strict_formatting, check_sets):
     """Runs all checks from check_sites and RWSCheck whose exceptions should
     not cause the program to immediately exit.
@@ -148,7 +149,6 @@ def main():
         print(f"There was an error when parsing the JSON;\nerror was:  {inst}")
         return
 
-
     # Load the etlds from the public suffix list
     etlds = PublicSuffixList(psl_file="effective_tld_names.dat")
     # Get all the ICANN domains
@@ -166,7 +166,7 @@ def main():
         # If the schema is invalid, we will not run any other checks
         print(inst)
         return
-    
+
     error_texts = []
     check_sets = {}
     subtracted_sets = {}

--- a/check_sites.py
+++ b/check_sites.py
@@ -72,8 +72,7 @@ def find_diff_sets(old_sets, new_sets):
     }
     return diff_sets, subtracted_sets
 
-def run_nonbreaking_checks(rws_checker, rws_json_string,
-                               strict_formatting, check_sets):
+def run_nonbreaking_checks(rws_checker, rws_json_string, strict_formatting, check_sets):
     """Runs all checks from check_sites and RWSCheck whose exceptions should
     not cause the program to immediately exit.
 
@@ -90,10 +89,11 @@ def run_nonbreaking_checks(rws_checker, rws_json_string,
         [String]
     """
     error_texts = []
-    if strict_formatting and (format_diff := find_format_diff(rws_json_string,
-                                                              rws_checker.rws_sites)):
-            error_texts.append(format_diff)
-    
+    if strict_formatting and (
+        format_diff := find_format_diff(rws_json_string, rws_checker.rws_sites)
+    ):
+        error_texts.append(format_diff)
+
     try:
         rws_checker.check_exclusivity(rws_checker.load_sets())
     except Exception as inst:
@@ -117,8 +117,9 @@ def run_nonbreaking_checks(rws_checker, rws_json_string,
             check(check_sets)
         except Exception as inst:
             error_texts.append(inst)
-    
+
     return error_texts
+
 
 def main():
     args = sys.argv[1:]
@@ -146,6 +147,7 @@ def main():
         # If the file cannot be loaded, we will not run any other checks
         print(f"There was an error when parsing the JSON;\nerror was:  {inst}")
         return
+
 
     # Load the etlds from the public suffix list
     etlds = PublicSuffixList(psl_file="effective_tld_names.dat")
@@ -202,8 +204,9 @@ def main():
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)
     # Run remaining technical checks
-    error_texts += run_nonbreaking_checks(rws_checker, rws_json_string,
-                                  strict_formatting, check_sets)
+    error_texts += run_nonbreaking_checks(
+        rws_checker, rws_json_string, strict_formatting, check_sets
+    )
     # This message allows us to check the succes of our action
     if rws_checker.error_list or error_texts:
         for checker_error in rws_checker.error_list:

--- a/check_sites.py
+++ b/check_sites.py
@@ -22,38 +22,28 @@ from publicsuffix2 import PublicSuffixList
 from RwsCheck import RwsCheck
 
 
-def parse_rws_json(rws_json_string, strict_formatting):
-    """Attempts to parse `rws_json_string` as JSON and validate formatting if `strict_formatting` is true.
-
-    Returns a tuple of the JSON dict and None if there were no formatting
-    errors, or None and the error message if there was an error.  If the file
-    is not proper json, `json.loads()` will throw a JSONDecodeError.
+def find_format_diff(rws_json_string, rws_sites):
+    """Returns the diff of the rws_json_string and the formatted string
+    generated from rws_sites.
 
     Args:
         rws_json_string: string
-        strict_formatting: bool
+        rws_sites: JSON Object
     Returns:
-        Tuple[Dict|None, string|None]
+        String
     """
-    # If this fails, it needs to be caught in the caller.
-    rws_sites = json.loads(rws_json_string)
-    # Notify of any formatting errors in the JSON
-    if strict_formatting:
-        # Add final newline by convention
-        formatted_file = json.dumps(rws_sites, indent=2, ensure_ascii=False) + "\n"
-        if rws_json_string != formatted_file:
-            diff = difflib.unified_diff(
-                rws_json_string.splitlines(keepends=True),
-                formatted_file.splitlines(keepends=True),
-                fromfile="PR file",
-                tofile="expected",
-            )
-            joined_diff = "".join(diff)
-            return (
-                None,
-                f"Formatting for JSON is incorrect;\nerror was:\n```diff\n{joined_diff}\n```",
-            )
-    return (rws_sites, None)
+    # Add final newline by convention
+    formatted_file = json.dumps(rws_sites, indent=2, ensure_ascii=False) + "\n"
+    if rws_json_string == formatted_file:
+        return ""
+    diff = difflib.unified_diff(
+        rws_json_string.splitlines(keepends=True),
+        formatted_file.splitlines(keepends=True),
+        fromfile="PR file",
+        tofile="expected",
+    )
+    joined_diff = "".join(diff)
+    return f"Formatting for JSON is incorrect;\nerror was:\n```diff\n{joined_diff}\n```"
 
 
 def find_diff_sets(old_sets, new_sets):
@@ -82,6 +72,53 @@ def find_diff_sets(old_sets, new_sets):
     }
     return diff_sets, subtracted_sets
 
+def run_nonbreaking_checks(rws_checker, rws_json_string,
+                               strict_formatting, check_sets):
+    """Runs all checks from check_sites and RWSCheck whose exceptions should
+    not cause the program to immediately exit.
+
+    Returns a list of `error_texts` that result from running `find_format_diff`
+    as well as a number of RWSCheck functions. The RWSCheck function calls may
+    also result in changes to `rws_checker.error_list`.
+
+    Args:
+        rws_checker: RWSCheck object
+        rws_json_string: string
+        strict_formatting: boolean
+        check_sets: Dict[string, RwsSet]
+    Returns:
+        [String]
+    """
+    error_texts = []
+    if strict_formatting and (format_diff := find_format_diff(rws_json_string,
+                                                              rws_checker.rws_sites)):
+            error_texts.append(format_diff)
+    
+    try:
+        rws_checker.check_exclusivity(rws_checker.load_sets())
+    except Exception as inst:
+        error_texts.append(inst)
+
+    # These are RWSCheck functions that may append to the
+    # rws_checker's error_list.
+    check_list = [
+        rws_checker.has_all_rationales,
+        rws_checker.find_non_https_urls,
+        rws_checker.find_invalid_eTLD_Plus1,
+        rws_checker.find_invalid_well_known,
+        rws_checker.find_invalid_alias_eSLDs,
+        rws_checker.find_robots_tag,
+        rws_checker.find_ads_txt,
+        rws_checker.check_for_service_redirect,
+    ]
+
+    for check in check_list:
+        try:
+            check(check_sets)
+        except Exception as inst:
+            error_texts.append(inst)
+    
+    return error_texts
 
 def main():
     args = sys.argv[1:]
@@ -103,21 +140,11 @@ def main():
             cli_primaries.extend(arg.split(","))
 
     rws_json_string = pathlib.Path(input_filepath).read_text()
-    error_texts = []
     try:
-        (rws_sites, error) = parse_rws_json(rws_json_string, strict_formatting)
+        rws_sites = json.loads(rws_json_string)
     except Exception as inst:
         # If the file cannot be loaded, we will not run any other checks
         print(f"There was an error when parsing the JSON;\nerror was:  {inst}")
-        return
-    if error is not None:
-        error_texts.append(error)
-
-    try:
-        rws_checker.validate_schema("SCHEMA.json")
-    except Exception as inst:
-        # If the schema is invalid, we will not run any other checks
-        print(inst)
         return
 
     # Load the etlds from the public suffix list
@@ -131,12 +158,14 @@ def main():
 
     rws_checker = RwsCheck(rws_sites, etlds, icanns)
 
-    # Check for exclusivity among all sets in the updated version
     try:
-        rws_checker.check_exclusivity(rws_checker.load_sets())
+        rws_checker.validate_schema("SCHEMA.json")
     except Exception as inst:
-        error_texts.append(inst)
-
+        # If the schema is invalid, we will not run any other checks
+        print(inst)
+        return
+    
+    error_texts = []
     check_sets = {}
     subtracted_sets = {}
     # If called with with_diff, we must determine the sets that are different
@@ -172,24 +201,9 @@ def main():
 
     # Run check on subtracted sets
     rws_checker.find_invalid_removal(subtracted_sets)
-
-    # Run rest of checks
-    check_list = [
-        rws_checker.has_all_rationales,
-        rws_checker.find_non_https_urls,
-        rws_checker.find_invalid_eTLD_Plus1,
-        rws_checker.find_invalid_well_known,
-        rws_checker.find_invalid_alias_eSLDs,
-        rws_checker.find_robots_tag,
-        rws_checker.find_ads_txt,
-        rws_checker.check_for_service_redirect,
-    ]
-
-    for check in check_list:
-        try:
-            check(check_sets)
-        except Exception as inst:
-            error_texts.append(inst)
+    # Run remaining technical checks
+    error_texts += run_nonbreaking_checks(rws_checker, rws_json_string,
+                                  strict_formatting, check_sets)
     # This message allows us to check the succes of our action
     if rws_checker.error_list or error_texts:
         for checker_error in rws_checker.error_list:

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from json import JSONDecodeError
 import re
 import sys
 import unittest
@@ -30,13 +31,12 @@ class TestLoadFile(unittest.TestCase):
     """A test suite for the parse_rws_json function"""
 
     def test_parse_only(self):
-        self.assertEqual(
-            parse_rws_json("this is not json", False),
-            (
-                None,
-                "There was an error when parsing the JSON;\nerror was:  Expecting value: line 1 column 1 (char 0)",
-            ),
-        )
+        with self.assertRaisesRegex(
+            JSONDecodeError,
+            "Expecting value: line 1 column 1 \(char 0\)",
+        ):
+            parse_rws_json("this is not json", False)
+            
         self.assertEqual(
             parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', False),
             ({"a": "foo", "b": "bar"}, None),
@@ -47,13 +47,12 @@ class TestLoadFile(unittest.TestCase):
         )
 
     def test_parse_and_check_format(self):
-        self.assertEqual(
-            parse_rws_json("this is not json", True),
-            (
-                None,
-                "There was an error when parsing the JSON;\nerror was:  Expecting value: line 1 column 1 (char 0)",
-            ),
-        )
+        with self.assertRaisesRegex(
+            JSONDecodeError,
+            "Expecting value: line 1 column 1 \(char 0\)",
+        ):
+            parse_rws_json("this is not json", False)
+        
         self.assertEqual(
             parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', True),
             (

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from json import JSONDecodeError
 import json
 import re
 import sys
@@ -35,7 +34,7 @@ class TestFindFormatDiff(unittest.TestCase):
         invalid_format_string = '{\n  "a": "foo", \n    "b": "bar"\n}\n  '
         self.assertEqual(
             find_format_diff(invalid_format_string, json.loads(invalid_format_string)),
-                """Formatting for JSON is incorrect;
+            """Formatting for JSON is incorrect;
 error was:
 ```diff
 --- PR file
@@ -48,14 +47,13 @@ error was:
 +  "b": "bar"
  }
 -  
-```"""
+```""",
         )
-        
+
     def test_valid_format(self):
         valid_format_string = '{\n  "a": "foo",\n  "b": "bar"\n}\n'
         self.assertEqual(
-            find_format_diff(valid_format_string, json.loads(valid_format_string)),
-            ""
+            find_format_diff(valid_format_string, json.loads(valid_format_string)), ""
         )
 
 
@@ -1591,11 +1589,12 @@ class MockTestsClass(unittest.TestCase):
             ],
         )
 
+
 class TestRunNonbreakingChecks(unittest.TestCase):
     """A test suite for the run_nonbreaking_checks function.
     Uses mock_get and mock_open_and_load_json."""
 
-    VALID_JSON_STRING = '''{
+    VALID_JSON_STRING = """{
   "sets": [
     {
       "primary": "https://primary4.com",
@@ -1608,8 +1607,8 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     }
   ]
 }
-'''
-    BAD_FORMAT_JSON_STRING = '''{
+"""
+    BAD_FORMAT_JSON_STRING = """{
   "sets":[
     {
       "primary": "https://primary4.com",
@@ -1622,8 +1621,8 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     }
   ]
 }
-'''
-    NO_RATIONALES_JSON_STRING = '''{
+"""
+    NO_RATIONALES_JSON_STRING = """{
   "sets": [
     {
       "primary": "https://primary4.com",
@@ -1634,8 +1633,8 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     }
   ]
 }
-'''
-    BAD_FORMAT_NO_RATIONALES_JSON_STRING = '''{
+"""
+    BAD_FORMAT_NO_RATIONALES_JSON_STRING = """{
   "sets":[
     {
       "primary": "https://primary4.com",
@@ -1646,7 +1645,7 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     }
   ]
 }
-'''
+"""
 
     @mock.patch("requests.get", side_effect=mock_get)
     @mock.patch(
@@ -1654,13 +1653,17 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     )
     def testValidRWSJSONString(self, mock_get, mock_open_and_load_json):
         # Assert requests.get calls
-        rws_check = RwsCheck(rws_sites=json.loads(self.VALID_JSON_STRING),
-                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-                             icanns=set())
-        error_texts = run_nonbreaking_checks(rws_check,
-                                  self.VALID_JSON_STRING,
-                                  strict_formatting=True,
-                                  check_sets=rws_check.load_sets())
+        rws_check = RwsCheck(
+            rws_sites=json.loads(self.VALID_JSON_STRING),
+            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set()
+        )
+        error_texts = run_nonbreaking_checks(
+            rws_check,
+            self.VALID_JSON_STRING,
+            strict_formatting=True,
+            check_sets=rws_check.load_sets()
+        )
         self.assertEqual(error_texts + rws_check.error_list, [])
 
     @mock.patch("requests.get", side_effect=mock_get)
@@ -1668,15 +1671,21 @@ class TestRunNonbreakingChecks(unittest.TestCase):
         "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
     )
     def testFormatErrors(self, mock_get, mock_open_and_load_json):
-        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_JSON_STRING),
-                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-                             icanns=set())
-        error_texts = run_nonbreaking_checks(rws_check,
-                                  self.BAD_FORMAT_JSON_STRING,
-                                  strict_formatting=True,
-                                  check_sets=rws_check.load_sets())
-        self.assertEqual(error_texts + rws_check.error_list,
-                         ["""Formatting for JSON is incorrect;
+        rws_check = RwsCheck(
+            rws_sites=json.loads(self.BAD_FORMAT_JSON_STRING),
+            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set()
+        )
+        error_texts = run_nonbreaking_checks(
+            rws_check,
+            self.BAD_FORMAT_JSON_STRING,
+            strict_formatting=True,
+            check_sets=rws_check.load_sets()
+        )
+        self.assertEqual(
+            error_texts + rws_check.error_list,
+            [
+                """Formatting for JSON is incorrect;
 error was:
 ```diff
 --- PR file
@@ -1689,36 +1698,51 @@ error was:
        "primary": "https://primary4.com",
        "associatedSites": [
 
-```"""])
+```"""
+            ],
+        )
 
     @mock.patch("requests.get", side_effect=mock_get)
     @mock.patch(
         "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
     )
     def testTechnicalErrors(self, mock_get, mock_open_and_load_json):
-        rws_check = RwsCheck(rws_sites=json.loads(self.NO_RATIONALES_JSON_STRING),
-                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-                             icanns=set())
-        error_texts = run_nonbreaking_checks(rws_check,
-                                  self.NO_RATIONALES_JSON_STRING,
-                                  strict_formatting=True,
-                                  check_sets=rws_check.load_sets())
-        self.assertEqual(error_texts + rws_check.error_list, ['There is no provided rationale for https://associated3.com'])
+        rws_check = RwsCheck(
+            rws_sites=json.loads(self.NO_RATIONALES_JSON_STRING),
+            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set()
+        )
+        error_texts = run_nonbreaking_checks(
+            rws_check,
+            self.NO_RATIONALES_JSON_STRING,
+            strict_formatting=True,
+            check_sets=rws_check.load_sets()
+        )
+        self.assertEqual(
+            error_texts + rws_check.error_list,
+            ["There is no provided rationale for https://associated3.com"],
+        )
 
     @mock.patch("requests.get", side_effect=mock_get)
     @mock.patch(
         "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
     )
     def testTechnicalAndFormatErrors(self, mock_get, mock_open_and_load_json):
-        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
-                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-                             icanns=set())
-        error_texts = run_nonbreaking_checks(rws_check,
-                                  self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
-                                  strict_formatting=True,
-                                  check_sets=rws_check.load_sets())
-        self.assertEqual(error_texts + rws_check.error_list,
-                         ["""Formatting for JSON is incorrect;
+        rws_check = RwsCheck(
+            rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
+            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set()
+        )
+        error_texts = run_nonbreaking_checks(
+            rws_check,
+            self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
+            strict_formatting=True,
+            check_sets=rws_check.load_sets()
+        )
+        self.assertEqual(
+            error_texts + rws_check.error_list,
+            [
+                """Formatting for JSON is incorrect;
 error was:
 ```diff
 --- PR file
@@ -1732,23 +1756,31 @@ error was:
        "associatedSites": [
 
 ```""",
-        'There is no provided rationale for https://associated3.com'])
+                "There is no provided rationale for https://associated3.com",
+            ],
+        )
 
     @mock.patch("requests.get", side_effect=mock_get)
     @mock.patch(
         "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
     )
     def testNoStrictFormatting(self, mock_get, mock_open_and_load_json):
-        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
-                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-                             icanns=set())
-        error_texts = run_nonbreaking_checks(rws_check,
-                                  self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
-                                  strict_formatting=False,
-                                  check_sets=rws_check.load_sets())
+        rws_check = RwsCheck(
+            rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
+            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set()
+        )
+        error_texts = run_nonbreaking_checks(
+            rws_check,
+            self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
+            strict_formatting=False,
+            check_sets=rws_check.load_sets()
+        )
         # Should only see technical errors.
-        self.assertEqual(error_texts + rws_check.error_list,
-                         ['There is no provided rationale for https://associated3.com'])
+        self.assertEqual(
+            error_texts + rws_check.error_list,
+            ["There is no provided rationale for https://associated3.com"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -36,7 +36,7 @@ class TestLoadFile(unittest.TestCase):
             "Expecting value: line 1 column 1 \(char 0\)",
         ):
             parse_rws_json("this is not json", False)
-            
+
         self.assertEqual(
             parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', False),
             ({"a": "foo", "b": "bar"}, None),
@@ -52,7 +52,7 @@ class TestLoadFile(unittest.TestCase):
             "Expecting value: line 1 column 1 \(char 0\)",
         ):
             parse_rws_json("this is not json", False)
-        
+
         self.assertEqual(
             parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', True),
             (

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -1655,14 +1655,14 @@ class TestRunNonbreakingChecks(unittest.TestCase):
         # Assert requests.get calls
         rws_check = RwsCheck(
             rws_sites=json.loads(self.VALID_JSON_STRING),
-            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-            icanns=set()
+            etlds=PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set(),
         )
         error_texts = run_nonbreaking_checks(
             rws_check,
             self.VALID_JSON_STRING,
             strict_formatting=True,
-            check_sets=rws_check.load_sets()
+            check_sets=rws_check.load_sets(),
         )
         self.assertEqual(error_texts + rws_check.error_list, [])
 
@@ -1673,14 +1673,14 @@ class TestRunNonbreakingChecks(unittest.TestCase):
     def testFormatErrors(self, mock_get, mock_open_and_load_json):
         rws_check = RwsCheck(
             rws_sites=json.loads(self.BAD_FORMAT_JSON_STRING),
-            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-            icanns=set()
+            etlds=PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set(),
         )
         error_texts = run_nonbreaking_checks(
             rws_check,
             self.BAD_FORMAT_JSON_STRING,
             strict_formatting=True,
-            check_sets=rws_check.load_sets()
+            check_sets=rws_check.load_sets(),
         )
         self.assertEqual(
             error_texts + rws_check.error_list,
@@ -1709,14 +1709,14 @@ error was:
     def testTechnicalErrors(self, mock_get, mock_open_and_load_json):
         rws_check = RwsCheck(
             rws_sites=json.loads(self.NO_RATIONALES_JSON_STRING),
-            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-            icanns=set()
+            etlds=PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set(),
         )
         error_texts = run_nonbreaking_checks(
             rws_check,
             self.NO_RATIONALES_JSON_STRING,
             strict_formatting=True,
-            check_sets=rws_check.load_sets()
+            check_sets=rws_check.load_sets(),
         )
         self.assertEqual(
             error_texts + rws_check.error_list,
@@ -1730,14 +1730,14 @@ error was:
     def testTechnicalAndFormatErrors(self, mock_get, mock_open_and_load_json):
         rws_check = RwsCheck(
             rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
-            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-            icanns=set()
+            etlds=PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set(),
         )
         error_texts = run_nonbreaking_checks(
             rws_check,
             self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
             strict_formatting=True,
-            check_sets=rws_check.load_sets()
+            check_sets=rws_check.load_sets(),
         )
         self.assertEqual(
             error_texts + rws_check.error_list,
@@ -1767,14 +1767,14 @@ error was:
     def testNoStrictFormatting(self, mock_get, mock_open_and_load_json):
         rws_check = RwsCheck(
             rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
-            etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
-            icanns=set()
+            etlds=PublicSuffixList(psl_file="effective_tld_names.dat"),
+            icanns=set(),
         )
         error_texts = run_nonbreaking_checks(
             rws_check,
             self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
             strict_formatting=False,
-            check_sets=rws_check.load_sets()
+            check_sets=rws_check.load_sets(),
         )
         # Should only see technical errors.
         self.assertEqual(

--- a/tests/rws_tests.py
+++ b/tests/rws_tests.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from json import JSONDecodeError
+import json
 import re
 import sys
 import unittest
@@ -22,41 +23,18 @@ from unittest import mock
 from requests import structures
 
 sys.path.append(".")
-from check_sites import find_diff_sets, parse_rws_json
+from check_sites import find_diff_sets, find_format_diff, run_nonbreaking_checks
 from RwsCheck import RwsCheck, WELL_KNOWN
 from RwsSet import RwsSet
 
 
-class TestLoadFile(unittest.TestCase):
-    """A test suite for the parse_rws_json function"""
+class TestFindFormatDiff(unittest.TestCase):
+    """A test suite for the find_format_diff function"""
 
-    def test_parse_only(self):
-        with self.assertRaisesRegex(
-            JSONDecodeError,
-            "Expecting value: line 1 column 1 \(char 0\)",
-        ):
-            parse_rws_json("this is not json", False)
-
+    def test_invalid_format(self):
+        invalid_format_string = '{\n  "a": "foo", \n    "b": "bar"\n}\n  '
         self.assertEqual(
-            parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', False),
-            ({"a": "foo", "b": "bar"}, None),
-        )
-        self.assertEqual(
-            parse_rws_json('{\n  "a": "foo",\n  "b": "bar"\n}\n', False),
-            ({"a": "foo", "b": "bar"}, None),
-        )
-
-    def test_parse_and_check_format(self):
-        with self.assertRaisesRegex(
-            JSONDecodeError,
-            "Expecting value: line 1 column 1 \(char 0\)",
-        ):
-            parse_rws_json("this is not json", False)
-
-        self.assertEqual(
-            parse_rws_json('{\n  "a": "foo", \n    "b": "bar"\n}\n  ', True),
-            (
-                None,
+            find_format_diff(invalid_format_string, json.loads(invalid_format_string)),
                 """Formatting for JSON is incorrect;
 error was:
 ```diff
@@ -70,12 +48,14 @@ error was:
 +  "b": "bar"
  }
 -  
-```""",
-            ),
+```"""
         )
+        
+    def test_valid_format(self):
+        valid_format_string = '{\n  "a": "foo",\n  "b": "bar"\n}\n'
         self.assertEqual(
-            parse_rws_json('{\n  "a": "foo",\n  "b": "bar"\n}\n', True),
-            ({"a": "foo", "b": "bar"}, None),
+            find_format_diff(valid_format_string, json.loads(valid_format_string)),
+            ""
         )
 
 
@@ -1610,6 +1590,165 @@ class MockTestsClass(unittest.TestCase):
                 + "listed as its primary: https://associated3.ca",
             ],
         )
+
+class TestRunNonbreakingChecks(unittest.TestCase):
+    """A test suite for the run_nonbreaking_checks function.
+    Uses mock_get and mock_open_and_load_json."""
+
+    VALID_JSON_STRING = '''{
+  "sets": [
+    {
+      "primary": "https://primary4.com",
+      "associatedSites": [
+        "https://associated3.com"
+      ],
+      "rationaleBySite": {
+        "https://associated3.com": "a rationale"
+      }
+    }
+  ]
+}
+'''
+    BAD_FORMAT_JSON_STRING = '''{
+  "sets":[
+    {
+      "primary": "https://primary4.com",
+      "associatedSites": [
+        "https://associated3.com"
+      ],
+      "rationaleBySite": {
+        "https://associated3.com": "a rationale"
+      }
+    }
+  ]
+}
+'''
+    NO_RATIONALES_JSON_STRING = '''{
+  "sets": [
+    {
+      "primary": "https://primary4.com",
+      "associatedSites": [
+        "https://associated3.com"
+      ],
+      "rationaleBySite": {}
+    }
+  ]
+}
+'''
+    BAD_FORMAT_NO_RATIONALES_JSON_STRING = '''{
+  "sets":[
+    {
+      "primary": "https://primary4.com",
+      "associatedSites": [
+        "https://associated3.com"
+      ],
+      "rationaleBySite": {}
+    }
+  ]
+}
+'''
+
+    @mock.patch("requests.get", side_effect=mock_get)
+    @mock.patch(
+        "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
+    )
+    def testValidRWSJSONString(self, mock_get, mock_open_and_load_json):
+        # Assert requests.get calls
+        rws_check = RwsCheck(rws_sites=json.loads(self.VALID_JSON_STRING),
+                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+                             icanns=set())
+        error_texts = run_nonbreaking_checks(rws_check,
+                                  self.VALID_JSON_STRING,
+                                  strict_formatting=True,
+                                  check_sets=rws_check.load_sets())
+        self.assertEqual(error_texts + rws_check.error_list, [])
+
+    @mock.patch("requests.get", side_effect=mock_get)
+    @mock.patch(
+        "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
+    )
+    def testFormatErrors(self, mock_get, mock_open_and_load_json):
+        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_JSON_STRING),
+                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+                             icanns=set())
+        error_texts = run_nonbreaking_checks(rws_check,
+                                  self.BAD_FORMAT_JSON_STRING,
+                                  strict_formatting=True,
+                                  check_sets=rws_check.load_sets())
+        self.assertEqual(error_texts + rws_check.error_list,
+                         ["""Formatting for JSON is incorrect;
+error was:
+```diff
+--- PR file
++++ expected
+@@ -1,5 +1,5 @@
+ {
+-  "sets":[
++  "sets": [
+     {
+       "primary": "https://primary4.com",
+       "associatedSites": [
+
+```"""])
+
+    @mock.patch("requests.get", side_effect=mock_get)
+    @mock.patch(
+        "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
+    )
+    def testTechnicalErrors(self, mock_get, mock_open_and_load_json):
+        rws_check = RwsCheck(rws_sites=json.loads(self.NO_RATIONALES_JSON_STRING),
+                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+                             icanns=set())
+        error_texts = run_nonbreaking_checks(rws_check,
+                                  self.NO_RATIONALES_JSON_STRING,
+                                  strict_formatting=True,
+                                  check_sets=rws_check.load_sets())
+        self.assertEqual(error_texts + rws_check.error_list, ['There is no provided rationale for https://associated3.com'])
+
+    @mock.patch("requests.get", side_effect=mock_get)
+    @mock.patch(
+        "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
+    )
+    def testTechnicalAndFormatErrors(self, mock_get, mock_open_and_load_json):
+        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
+                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+                             icanns=set())
+        error_texts = run_nonbreaking_checks(rws_check,
+                                  self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
+                                  strict_formatting=True,
+                                  check_sets=rws_check.load_sets())
+        self.assertEqual(error_texts + rws_check.error_list,
+                         ["""Formatting for JSON is incorrect;
+error was:
+```diff
+--- PR file
++++ expected
+@@ -1,5 +1,5 @@
+ {
+-  "sets":[
++  "sets": [
+     {
+       "primary": "https://primary4.com",
+       "associatedSites": [
+
+```""",
+        'There is no provided rationale for https://associated3.com'])
+
+    @mock.patch("requests.get", side_effect=mock_get)
+    @mock.patch(
+        "RwsCheck.RwsCheck.open_and_load_json", side_effect=mock_open_and_load_json
+    )
+    def testNoStrictFormatting(self, mock_get, mock_open_and_load_json):
+        rws_check = RwsCheck(rws_sites=json.loads(self.BAD_FORMAT_NO_RATIONALES_JSON_STRING),
+                             etlds = PublicSuffixList(psl_file="effective_tld_names.dat"),
+                             icanns=set())
+        error_texts = run_nonbreaking_checks(rws_check,
+                                  self.BAD_FORMAT_NO_RATIONALES_JSON_STRING,
+                                  strict_formatting=False,
+                                  check_sets=rws_check.load_sets())
+        # Should only see technical errors.
+        self.assertEqual(error_texts + rws_check.error_list,
+                         ['There is no provided rationale for https://associated3.com'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, if `parse_rws_json` is called on a JSON file that is readable but not properly formatted, we only print the formatting errors and don't run any of the other technical checks. This change makes it so that as long JSON file is readable, we still attempt to run all other technical checks so that submitters can see if their submission is invalid in other ways aside from their formatting.