### PR TITLE
Adds a Related Website Set for tcappliancehvac.com

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1047,11 +1047,12 @@
     {
  {
   "primary": "tcappliancehvac.com",
-  "contact": "support@tcappliancehvac.com",
+  "contact": "tcappliancehvac@gmail.com",
   "associatedSites": [
     "tcappliancerepairman.com"
   ],
   "rationaleBySite": {
-    "tcappliancerepairman.com": "Same company — alternate domain for appliance repair services"
+    "tcappliancerepairman.com": "Same company — alternate domain for T&C Appliance HVAC Repair Services"
   }
 }
+"ChandieFae/related_website_sets @github.com"

--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1044,13 +1044,14 @@
       }
     },
     {
-      "owner": "tcappliancehvac.com",
-      "primary": "tcappliancehvac.com",
-      "associatedSites": [
-        "tcappliancerepairman.com"
-      ],
-      "service": [],
-      "comment": "Related Website Set for T&C Appliance & HVAC Repair"
-    }
-  ]
+    {
+ {
+  "primary": "tcappliancehvac.com",
+  "contact": "support@tcappliancehvac.com",
+  "associatedSites": [
+    "tcappliancerepairman.com"
+  ],
+  "rationaleBySite": {
+    "tcappliancerepairman.com": "Same company — alternate domain for appliance repair services"
+  }
 }

--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1046,13 +1046,6 @@
     {
     {
  {
-  "primary": "tcappliancehvac.com",
-  "contact": "tcappliancehvac@gmail.com",
-  "associatedSites": [
-    "tcappliancerepairman.com"
-  ],
-  "rationaleBySite": {
-    "tcappliancerepairman.com": "Same company — alternate domain for T&C Appliance HVAC Repair Services"
+
   }
-}
-"ChandieFae/related_website_sets @github.com"
+

--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -1026,6 +1026,15 @@
       "rationaleBySite": {
         "https://brendanjkane.com": "Brendan Kane is Hook Point's founder and CEO. This is clearly stated on Brendan's website, including links to Hook Point's website, and Brendan's face and name are also featured on Hook Point's website."
       }
+    },
+    {
+      "owner": "tcappliancehvac.com",
+      "primary": "tcappliancehvac.com",
+      "associatedSites": [
+        "tcappliancerepairman.com"
+      ],
+      "service": [],
+      "comment": "Related Website Set for T&C Appliance & HVAC Repair"
     }
   ]
 }

--- a/related_website_sets.json
+++ b/related_website_sets.json
@@ -1,9 +1,0 @@
-{
-  "owner": "tcappliancehvac.com",
-  "primary": "tcappliancehvac.com",
-  "associatedSites": [
-    "tcappliancerepairman.com"
-  ],
-  "service": [],
-  "comment": "Related Website Set for T&C Appliance & HVAC Repair"
-}

--- a/related_website_sets.json
+++ b/related_website_sets.json
@@ -1,0 +1,9 @@
+{
+  "owner": "tcappliancehvac.com",
+  "primary": "tcappliancehvac.com",
+  "associatedSites": [
+    "tcappliancerepairman.com"
+  ],
+  "service": [],
+  "comment": "Related Website Set for T&C Appliance & HVAC Repair"
+}


### PR DESCRIPTION
Adds a Related Website Set for tcappliancehvac.com and tcappliancerepairman.com. These domains are owned by the same business and support cross-site session continuity for appliance/HVAC services. JSON: https://chandiefae.github.io/rws-tcappliancehvacrepair/related_website_sets.json