### PR TITLE
Fix regex-escaping bug

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -26,7 +26,7 @@ jobs:
         BODY: ${{ github.event.pull_request.bodyText }}
       with:
         script: |
-          const pattern = new RegExp("Not\s+a\s+Contribution", "i");
+          const pattern = /Not\s+a\s+Contribution/i;
           const { BODY, TITLE } = process.env;
 
           if (pattern.test(BODY) || pattern.test(TITLE)) {


### PR DESCRIPTION
The existing code used character classes within a string literal, so it should have double-escaped them, e.g. `"Not\\s+a..."`. JS provides a more concise syntax for regex literals which doesn't require double-escaping, so we'll use that instead.