### PR TITLE
Use `pull_request.body` instead of `pull_request.bodyText`

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/github-script@v7
       env:
         TITLE: ${{ github.event.pull_request.title }}
-        BODY: ${{ github.event.pull_request.bodyText }}
+        BODY: ${{ github.event.pull_request.body }}
       with:
         script: |
           const pattern = /Not\s+a\s+Contribution/i;


### PR DESCRIPTION
Apparently `bodyText` doesn't exist (per https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request), despite https://docs.github.com/en/graphql/reference/objects#pullrequest saying it does.