### PR TITLE
Don't run checks on all RWS members

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -35,4 +35,3 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         python3 tests/rws_tests.py
-        python3 check_sites.py --strict_formatting


### PR DESCRIPTION
We aren't using the results, we already check any changes in the other job, and this is timing out due to the amount of fetches.